### PR TITLE
null check on clearandfill

### DIFF
--- a/recyclerviewsquire/src/main/java/com/alexgwyn/recyclerviewsquire/ArrayAdapter.java
+++ b/recyclerviewsquire/src/main/java/com/alexgwyn/recyclerviewsquire/ArrayAdapter.java
@@ -40,7 +40,9 @@ public abstract class ArrayAdapter<T, V extends RecyclerView.ViewHolder> extends
 
     public void clearAndFill(Collection<T> items) {
         mItems.clear();
-        mItems.addAll(items);
+        if (items != null) {
+            mItems.addAll(items);
+        }
         notifyDataSetChanged();
     }
 


### PR DESCRIPTION
So, this would allow someone to call `clearAndFill(null)` so that they would not have to do something like

```
if (newData == null) {
adapter.clear();
} else {
adapter.clearAndFill(newData);
}
```

I think it makes sense this way and wouldn't really have any negative effects. Whatcha think, @AlexKGwyn 
